### PR TITLE
Fixed intermittent user activation error

### DIFF
--- a/includes/helpers/permalinks.php
+++ b/includes/helpers/permalinks.php
@@ -255,6 +255,13 @@ function uwp_process_activation_link() {
         $key =  strip_tags(esc_sql($_GET['key']));
         $login =  strip_tags(esc_sql($_GET['login']));
         $login_page = uwp_get_page_id('login_page', false);
+
+		// check_password_reset_key() pulls the activation ID from the cache, which can be unreliable for newly-created users.
+		// Clear the relevant cache section before we proceed.
+		$user = get_userdatabylogin($login);
+		if ($user)
+            wp_cache_delete($user->ID, 'users');
+            
         $result = check_password_reset_key($key, $login);
 
         if (is_wp_error($result)) {


### PR DESCRIPTION
Trying to activate a user immediately after it is created often leads to failures (uwp_err=act_wrong), especially on hosts that have an agressive cache policy such as WPEngine. Added code to clear the relevant section of the cache before matching the activation key.