### PR TITLE
Fix redirection error on account page actions menu

### DIFF
--- a/includes/helpers/misc.php
+++ b/includes/helpers/misc.php
@@ -548,7 +548,7 @@ function uwp_add_account_menu_links() {
 	}
 
 	$account_page = uwp_get_page_id('account_page', false);
-	$account_page_link = get_permalink($account_page);
+	$account_page_link = get_permalink($account_page).wp_get_current_user()->user_login;
 
 	$account_available_tabs = uwp_account_get_available_tabs();
 


### PR DESCRIPTION
Hello team,

Thanks for your hard work with this plugin.

I detected a bug inside the `/account` page, the links to change password, privacy or 2FA doesn't work as expected.
After some research, I could see that the account page has at the end the user login redirection and it does an infinite redirection.
I don't know if there is a better solution for this problem only one proposal.

Regards!