### PR TITLE
Add slug field instead of converting the form title

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -845,7 +845,7 @@ class UsersWP_Admin {
 		}
 
 		$type       = ! empty( $_POST['type'] ) ? sanitize_text_field($_POST['type']) : '';
-		$form_title = ! empty( $_POST['form_title'] ) ? sanitize_title_with_dashes($_POST['form_title']) : '';
+		$form_title = ! empty( $_POST['form_title'] ) ? sanitize_text_field($_POST['form_title']) : '';
 		$nonce      = ! empty( $_POST['nonce'] ) ? sanitize_text_field($_POST['nonce']) : '';
 
 		$status   = false;
@@ -861,6 +861,7 @@ class UsersWP_Admin {
 				$get_register_forms[] = array(
 					'id'    => $new_form_id,
 					'title' => ! empty( $form_title ) ? sanitize_text_field( $form_title ) : sprintf( __( 'Form %d', 'userswp' ), $new_form_id ),
+					'slug' => ! empty( $form_title ) ? sanitize_title_with_dashes( $form_title ) : sprintf( __( 'form-%d', 'userswp' ), $new_form_id ),
 				);
 
 				uwp_update_option( 'multiple_registration_forms', $get_register_forms );

--- a/admin/settings/class-formbuilder.php
+++ b/admin/settings/class-formbuilder.php
@@ -317,7 +317,7 @@ class UsersWP_Form_Builder {
 											<?php
 											foreach ( $register_forms as $key => $forms ) {
 												$form_id     = ! empty( $forms['id'] ) ? $forms['id'] : '';
-												$form_title  = ! empty( $forms['title'] ) ? sanitize_title_with_dashes($forms['title']) : '';
+												$form_title  = ! empty( $forms['title'] ) ? $forms['title'] : '';
 												$user_role   = ! empty( $forms['user_role'] ) ? $forms['user_role'] : '';
 												$action      = ! empty( $forms['reg_action'] ) ? $forms['reg_action'] : $current_action;
 												$redirect_to = isset( $forms['redirect_to'] ) ? $forms['redirect_to'] : '';
@@ -500,7 +500,7 @@ class UsersWP_Form_Builder {
 										<?php
 										foreach ( $register_forms as $key => $forms ) {
 											$form_id    = ! empty( $forms['id'] ) ? $forms['id'] : '';
-											$form_title = ! empty( $forms['title'] ) ? sanitize_title_with_dashes($forms['title']) : '';
+											$form_title = ! empty( $forms['title'] ) ? $forms['title'] : '';
 											?>
                                             <option <?php selected( $current_form, $form_id ); ?>
                                                     value="<?php echo $register_tab . '&form=' . $form_id; ?>"><?php echo sprintf( __( '%s - #%s', 'userswp' ), $form_title, $form_id ); ?></option>

--- a/includes/helpers/forms.php
+++ b/includes/helpers/forms.php
@@ -247,10 +247,10 @@ function uwp_get_custom_field_info( $htmlvar_name, $form_type = 'account' ) {
 	} else {
 		$field = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM " . $table_name . " WHERE htmlvar_name = %s", array( $htmlvar_name ) ) );
 	}
-	
+
 	// Cache the field data.
 	$custom_field_info[ $cache_key ] = $field;
-	
+
 	return $field;
 }
 
@@ -413,7 +413,7 @@ function uwp_get_form_id_by_type($form_type){
 
 			foreach ( $get_register_form as $key => $register_form ) {
 
-				if ( ! empty( $register_form['title'] ) && $form_type == sanitize_title_with_dashes($register_form['title']) ) {
+				if ( ! empty( $register_form['title'] ) && $form_type == $register_form['slug'] ) {
 
 					$form_id = $register_form['id'];
 				}


### PR DESCRIPTION
Adding a new filed slug instead of sanitizing the form title with sanitize_title_with_dashes would be better since the form titles being shown are with dashes. 

Fix for issue #711 