### PR TITLE
Fix validation issue where account fields incorrectly affected registration form

### DIFF
--- a/includes/helpers/forms.php
+++ b/includes/helpers/forms.php
@@ -50,7 +50,7 @@ function get_register_validate_form_fields( $form_id = 1 ) {
 	global $wpdb;
 	$table_name        = uwp_get_table_prefix() . 'uwp_form_fields';
 	$extras_table_name = uwp_get_table_prefix() . 'uwp_form_extras';
-	$fields = $wpdb->get_results( $wpdb->prepare( 'SELECT fields.* FROM ' . $table_name . ' fields JOIN ' . $extras_table_name . " extras ON extras.site_htmlvar_name = fields.htmlvar_name WHERE fields.form_type = %s AND fields.field_type != 'fieldset' AND fields.field_type != 'file' AND fields.is_active = '1' AND fields.for_admin_use != '1' AND fields.is_register_field = '1' AND fields.form_id = %s ORDER BY extras.sort_order ASC", array( 'account', $form_id ) ) );
+	$fields = $wpdb->get_results( $wpdb->prepare( 'SELECT fields.* FROM ' . $table_name . ' fields JOIN ' . $extras_table_name . " extras ON extras.site_htmlvar_name = fields.htmlvar_name WHERE fields.form_type = %s AND extras.form_type = 'register' AND fields.field_type != 'fieldset' AND fields.field_type != 'file' AND fields.is_active = '1' AND fields.for_admin_use != '1' AND fields.is_register_field = '1' AND extras.form_id = %d AND fields.form_id = %s ORDER BY extras.sort_order ASC", array( 'account', $form_id, $form_id ) ) );
 	$fields = apply_filters( 'uwp_get_register_validate_form_fields', $fields, $form_id );
 
 	return $fields;

--- a/readme.txt
+++ b/readme.txt
@@ -147,6 +147,7 @@ Yes, you can customize it with Elementor, but also with Gutenberg, Divi, Beaver 
 == Changelog ==
 
 = 1.2.29 - TBD =
+* Fixed an issue where fields required in the "Account" tab were incorrectly validated in the Registration Form. - FIXED
 * Username field in the registration form is now optional - CHANGED
 * Fixed an issue where selecting multiple options under "Show in what locations?" only saved one option - FIXED
 * Fixed Select2 error preventing multiselect dropdown in the Lightbox register form. - FIXED


### PR DESCRIPTION
### Changes:
Updated **get_register_validate_form_fields**() query to ensure only fields explicitly assigned to the registration form (extras.form_type = 'register') are validated.

### Steps to Reproduce the Bug:

- Navigate to UsersWP > Form Builder > Register Form.
- Remove the First Name and Last Name fields from the registration form.
- Go to UsersWP > Form Builder > Account.
- Find the First Name and Last Name fields and check:
**Include this field in register form**
**Is Required**
- Try signing up with a new account.
- Even though First Name and Last Name were removed from the Register Form, the form still requires them, causing validation errors.

**Expected Behavior:**
If First Name and Last Name are removed from the Register Form, they should not be validated during registration.

**Actual Behavior:**
The registration form still enforces First Name and Last Name as required fields due to their settings in the Account tab.
