### PR TITLE
Fixed Privacy tab settings on the Account page now reflect immediatel…

### DIFF
--- a/includes/class-meta.php
+++ b/includes/class-meta.php
@@ -145,7 +145,7 @@ class UsersWP_Meta {
 		if ( uwp_str_ends_with( $key, '_privacy' ) ) {
 			if ( 'tabs_privacy' == $key ) {
 				$obj_key = $user_id . '_tabs_privacy';
-				$cache_group = 'uwp_usermeta_tab_privacy';
+				$cache_group = 'uwp_usermeta_tabs_privacy';
 			} elseif('user_privacy' == $key) {
 				$obj_key = $user_id . '_user_privacy';
 				$cache_group = 'uwp_usermeta_user_privacy';

--- a/readme.txt
+++ b/readme.txt
@@ -161,6 +161,9 @@ Yes, you can customize it with Elementor, but also with Gutenberg, Divi, Beaver 
 
 == Changelog ==
 
+= 1.2.73 - 2026-09-TBD =
+* Privacy tab settings on the Account page now reflect immediately after saving, without needing to flush the object cache. - FIXED
+
 = 1.2.72 - 2026-08-18 =
 * Merge AUI 0.2.52 & SD 1.2.35 - CHANGED
 


### PR DESCRIPTION
…y after saving, without needing to flush the object cache.